### PR TITLE
add some const correctness, NULL

### DIFF
--- a/nweb23.c
+++ b/nweb23.c
@@ -21,8 +21,8 @@
 #endif
 
 struct {
-  char *ext;
-  char *filetype;
+  const char *ext;
+  const char *filetype;
 } extensions [] = {
   {"gif", "image/gif" },
   {"jpg", "image/jpg" },
@@ -36,7 +36,7 @@ struct {
   {"html","text/html" },
   {0,0} };
 
-void logger(int type, char *s1, char *s2, int socket_fd)
+void logger(int type, const char *s1, const char *s2, int socket_fd)
 {
   int fd ;
   char logbuffer[BUFSIZE*2];
@@ -68,7 +68,7 @@ void web(int fd, int hit)
 {
   int j, file_fd, buflen;
   long i, ret, len;
-  char * fstr;
+  const char * fstr;
   static char buffer[BUFSIZE+1]; /* static so zero filled */
 
   ret =read(fd,buffer,BUFSIZE);   /* read Web request in one go */
@@ -100,7 +100,7 @@ void web(int fd, int hit)
 
   /* work out the file type and check we support it */
   buflen=strlen(buffer);
-  fstr = (char *)0;
+  fstr = NULL;
   for(i=0;extensions[i].ext != 0;i++) {
     len = strlen(extensions[i].ext);
     if( !strncmp(&buffer[buflen-len], extensions[i].ext, len)) {


### PR DESCRIPTION
In order to deal with a ton of compiler warnings, here's some const-correctness added.
While at it, replace a `(char *)0` with NULL.  Personally I'd use an initialization, but you don't seem to like initializations so whatever :).

The warnings this addresses are:

> nweb23.c:27:3:
>
> warning: initialization discards ‘const’ qualifier from pointer target type
   {"gif", "image/gif" },
   ^
nweb23.c:27:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:28:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"jpg", "image/jpg" },
   ^
nweb23.c:28:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:29:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"jpeg","image/jpeg"},
   ^
nweb23.c:29:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:30:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"png", "image/png" },
   ^
nweb23.c:30:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:31:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"ico", "image/ico" },
   ^
nweb23.c:31:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:32:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"zip", "image/zip" },
   ^
nweb23.c:32:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:33:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"gz",  "image/gz"  },
   ^
nweb23.c:33:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:34:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"tar", "image/tar" },
   ^
nweb23.c:34:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:35:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"htm", "text/html" },
   ^
nweb23.c:35:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c:36:3: warning: initialization discards ‘const’ qualifier from pointer target type
   {"html","text/html" },
   ^
nweb23.c:36:3: warning: initialization discards ‘const’ qualifier from pointer target type
nweb23.c: In function ‘web’:
nweb23.c:76:22: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(FORBIDDEN,"failed to read browser request","",fd);
                      ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:76:55: warning: passing argument 3 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(FORBIDDEN,"failed to read browser request","",fd);
                                                       ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:84:14: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
   logger(LOG,"request",buffer,hit);
              ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:86:22: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(FORBIDDEN,"Only simple GET operation supported",buffer,fd);
                      ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:96:24: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
       logger(FORBIDDEN,"Parent directory (..) path names not supported",buffer,fd);
                        ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:111:34: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
   if(fstr == 0) logger(FORBIDDEN,"file extension type not supported",buffer,fd);
                                  ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:114:22: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(NOTFOUND, "failed to open file",&buffer[5],fd);
                      ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:116:14: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
   logger(LOG,"SEND",&buffer[5],hit);
              ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:120:14: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
   logger(LOG,"Header",buffer,hit);
              ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c: In function ‘main’:
nweb23.c:174:14: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
   logger(LOG,"nweb starting",argv[1],getpid());
              ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:177:19: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR, "system call","socket",0);
                   ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:177:33: warning: passing argument 3 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR, "system call","socket",0);
                                 ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:180:18: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR,"Invalid port number (try 1->60000)",argv[1],0);
                  ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:185:18: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR,"system call","bind",0);
                  ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:185:32: warning: passing argument 3 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR,"system call","bind",0);
                                ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:187:18: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR,"system call","listen",0);
                  ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:187:32: warning: passing argument 3 of ‘logger’ discards ‘const’ qualifier from pointer target type
     logger(ERROR,"system call","listen",0);
                                ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:191:20: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
       logger(ERROR,"system call","accept",0);
                    ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:191:34: warning: passing argument 3 of ‘logger’ discards ‘const’ qualifier from pointer target type
       logger(ERROR,"system call","accept",0);
                                  ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:193:20: warning: passing argument 2 of ‘logger’ discards ‘const’ qualifier from pointer target type
       logger(ERROR,"system call","fork",0);
                    ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^
nweb23.c:193:34: warning: passing argument 3 of ‘logger’ discards ‘const’ qualifier from pointer target type
       logger(ERROR,"system call","fork",0);
                                  ^
nweb23.c:39:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void logger(int type, char *s1, char *s2, int socket_fd)
      ^

Cheers,
fstd